### PR TITLE
Update builder to jdk-15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,58 @@
-FROM maven:3.5.3-jdk-11
+FROM openjdk:15-slim-buster
 
-RUN set -ex; \
-        \
-        echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/debian-backports.list; \
-        apt-get update; \
-        apt-get install -y --no-install-recommends \
-        libxslt1-dev \
-        libxml2 \
-        libsm6 \
-        libxext6 \
-        libglib2.0-0 \
-        build-essential \
-        g++ \
-        gcc \
-        git \
-        libffi-dev \
-        libssl-dev \
-        unzip \
-        ssh \
-        curl; \
-        apt-get -t jessie-backports -y --no-install-recommends install git; \
-        rm -rf /var/lib/apt/lists/*; \
-        \
-        VER="17.03.0-ce"; \
-        curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz; \
-        tar -xz -C /tmp -f /tmp/docker-$VER.tgz; \
-        rm /tmp/docker-$VER.tgz; \
-        mv /tmp/docker/* /usr/bin; \
-        cd /opt && curl --insecure -OL https://dl.bintray.com/sonarsource/SonarQube/org/sonarsource/scanner/cli/sonar-scanner-cli/3.0.3.778/sonar-scanner-cli-3.0.3.778-linux.zip && \
-        unzip sonar-scanner-cli-3.0.3.778-linux.zip && rm sonar-scanner-cli-3.0.3.778-linux.zip && \
-        ln -s /opt/sonar-scanner-3.0.3.778-linux/bin/sonar-scanner /usr/bin/
+ENV MVN_VERSION="3.6.3"
+ENV DOCKER_VERSION="docker-19.03.8"
+
+ENV MAVEN_HOME=/opt/maven
+ENV M2_HOME=/opt/maven
+ENV PATH=${M2_HOME}/bin:${PATH}
+
+RUN set -ex;
+
+# Base dependencies
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+      libxslt1-dev \
+      libxml2 \
+      libsm6 \
+      libxext6 \
+      libglib2.0-0 \
+      build-essential \
+      g++ \
+      gcc \
+      git \
+      libffi-dev \
+      libssl-dev \
+      unzip \
+      ssh \
+      wget \
+      curl;
+
+
+# ca-certificates 20200601 is broken and missing several valid certificates
+# until it is updated, we will pin to last stable version
+# https://tracker.debian.org/pkg/ca-certificates
+# https://qa.debian.org/cgi-bin/vcswatch?package=ca-certificates
+RUN apt-get update && \
+   apt-get install -y --no-install-recommends --allow-downgrades ca-certificates=20190110 && \
+   rm -rf /var/lib/apt/lists/*;
+
+
+RUN DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}.tgz" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true) \
+  && cd /opt && curl --insecure -OL https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.2.0.1873-linux.zip \
+  && unzip sonar-scanner-cli-4.2.0.1873-linux.zip && rm sonar-scanner-cli-4.2.0.1873-linux.zip \
+  && ln -s /opt/sonar-scanner-4.2.0.1873-linux/bin/sonar-scanner /usr/bin/
+
+# Download mvn
+RUN wget https://www-us.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz -P /tmp; \
+    tar xf /tmp/apache-maven-*.tar.gz -C /opt; \
+    ln -s /opt/apache-maven-${MVN_VERSION} /opt/maven; \
+    rm /tmp/apache-maven-*.tar.gz;


### PR DESCRIPTION
Turns out the mvn docker images switched to oracle linux at some point.
Therefore instead, I changed the base to openjdk, and installed the same
version of docker/sonar that python-dind-builder is using, and then
installed mvn manually.